### PR TITLE
Return unitful data for samplingrate

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -19,6 +19,8 @@ socio
 sexualized
 robertluke
 luke
+unitful
+samplerate
 Cz
 bdf
 md
@@ -35,10 +37,12 @@ Scherg
 BESA
 dat
 nAm
+mHz
 resampling
 subtype
 Epoching
 APIs
+Mol
 optodes
 neuroimaging
 fNIRS

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Types" => "types.md",
+        "Usage/Implementation Details" => Any["Accessing data"=>"usage/access.md",],
         "General EEG Processing" => Any[
             "Overview"=>"eeg/eeg.md",
             "Example"=>"eeg/examples.md",

--- a/docs/src/usage/access.md
+++ b/docs/src/usage/access.md
@@ -4,7 +4,7 @@ The `Neuroimaging.jl` library uses functions to access underlying
 properties of the data structures. This is to enable a consistent
 API to users, while allowing flexibility in the underlying design.
 
-To minimise the risk of making errors when specifyig values, passing
+To minimise the risk of making errors when specifying values, passing
 arguments, and scaling values, the `Neuroimaging.jl` library uses
 units wherever possible. The `Unitful.jl` package provides a convenient
 interface for handling unitful data.
@@ -13,7 +13,7 @@ interface for handling unitful data.
 ## Handling of units
 
 Many of the underlying components of this package store values with units.
-For example, coordinates are stored interally in the unit of meters,
+For example, coordinates are stored internally in the unit of meters,
 and sampling rates are stored in hertz. This minimises errors in two ways.
 First, if you pass arguments in the wrong order to a function it may be caught.
 Second, if you accidentally pass kHz as a sample rate this will be correctly
@@ -72,7 +72,7 @@ and in SI units. This makes it easy to keep track of everything
 when programming. However, when we report data these units may
 not be appropriate. For example, fNIRS data is usually reported in micro
 Mol, it would be inconvenient to report and plot values with six leading zeros.
-Simillarly locations of neuroimaging coordinates are often reported in milimeters.
+Similarly locations of neuroimaging coordinates are often reported in millimeters.
 So the `show` functions will report the data in the typical scale for the
 area of research.
 

--- a/docs/src/usage/access.md
+++ b/docs/src/usage/access.md
@@ -1,0 +1,82 @@
+# Accessing measurement properties
+
+The `Neuroimaging.jl` library uses functions to access underlying
+properties of the data structures. This is to enable a consistent
+API to users, while allowing flexibility in the underlying design.
+
+To minimise the risk of making errors when specifyig values, passing
+arguments, and scaling values, the `Neuroimaging.jl` library uses
+units wherever possible. The `Unitful.jl` package provides a convenient
+interface for handling unitful data.
+
+
+## Handling of units
+
+Many of the underlying components of this package store values with units.
+For example, coordinates are stored interally in the unit of meters,
+and sampling rates are stored in hertz. This minimises errors in two ways.
+First, if you pass arguments in the wrong order to a function it may be caught.
+Second, if you accidentally pass kHz as a sample rate this will be correctly
+converted to Hz for you internally.
+
+
+## Retrieving information from data
+
+To access information about your neuroimaging data you must query
+it using the provided functions. A list of functions is provided for each type
+in the documentation. And common functions available across all types are described
+in the types documentation.
+So for example, if you wanted to query the samplerate of a measurement:
+
+```@example fileread
+using Neuroimaging, DataDeps, Unitful
+data_path = joinpath(
+    datadep"ExampleSSR",
+    "Neuroimaging.jl-example-data-master",
+    "neuroimaingSSR.bdf",
+)
+s = read_EEG(data_path)
+samplingrate(s)
+```
+
+However, sometime you do not want the data with its units.
+Let us say you want the sample rate in kHz.
+In this case you can pipe the data manually...
+
+```@example fileread
+samplingrate(s) |> u"kHz" |> ustrip 
+```
+
+Or you may wish to know the sample rate in mHz and require
+that the value is an integer, then you could run...
+
+```@example fileread
+samplingrate(s) |> u"mHz" |> ustrip |> Int
+```
+
+Or you could simply specify the return type of the function...
+
+```@example fileread
+samplingrate(Float64, s)
+```
+
+You should access all properties of the data in this fashion.
+For example the functions `data`, `modulationrate`, `channel_names`
+should all be used to query this properties.
+
+
+## Displaying data properties
+
+The underlying data is stored with units wherever possible
+and in SI units. This makes it easy to keep track of everything
+when programming. However, when we report data these units may
+not be appropriate. For example, fNIRS data is usually reported in micro
+Mol, it would be inconvenient to report and plot values with six leading zeros.
+Simillarly locations of neuroimaging coordinates are often reported in milimeters.
+So the `show` functions will report the data in the typical scale for the
+area of research.
+
+
+```@example fileread
+show(sensors(s)[2])
+```

--- a/src/types/EEG/EEG.jl
+++ b/src/types/EEG/EEG.jl
@@ -18,7 +18,7 @@ abstract type EEG <: NeuroimagingMeasurement end
 
 import Base.show
 function Base.show(io::IO, a::EEG)
-    time_length = round.(size(a.data, 1) / samplingrate(a) / 60)
+    time_length = round.(size(a.data, 1) / samplingrate(Float64, a) / 60)
     println(
         io,
         "EEG measurement of $time_length mins with $(size(a.data,2)) channels sampled at $(a.samplingrate)",
@@ -62,7 +62,7 @@ s = read_EEG(filename)
 samplingrate(s)
 ```
 """
-samplingrate(s::EEG) = samplingrate(AbstractFloat, s)
+samplingrate(s::EEG) = s.samplingrate |> u"Hz"
 samplingrate(t, s::EEG) = convert(t, s.samplingrate |> u"Hz" |> ustrip)
 
 
@@ -563,13 +563,13 @@ end
 
 function trigger_channel(a::EEG; kwargs...)
 
-    create_channel(a.triggers, a.data, samplingrate(a))
+    create_channel(a.triggers, a.data, samplingrate(Float64, a))
 end
 
 
 function system_code_channel(a::EEG; kwargs...)
 
-    create_channel(a.system_codes, a.data, samplingrate(a))
+    create_channel(a.system_codes, a.data, samplingrate(Float64, a))
 end
 
 

--- a/src/types/EEG/plotting.jl
+++ b/src/types/EEG/plotting.jl
@@ -29,7 +29,7 @@ draw(PDF("timeseries.pdf", 10inch, 6inch), plot1)
 function plot_timeseries(
     s::EEG;
     channels::Union{S,Array{S}} = channelnames(s),
-    fs::Number = samplingrate(s),
+    fs::Number = samplingrate(Float64, s),
     kwargs...,
 ) where {S<:AbstractString}
 
@@ -41,7 +41,7 @@ function plot_timeseries(
 
         fig = plot_single_channel_timeseries(
             vec(keep_channel!(deepcopy(s), channels).data),
-            samplingrate(s);
+            samplingrate(Float64, s);
             kwargs...,
         )
 
@@ -57,7 +57,7 @@ function plot_timeseries(
         @debug("Plotting multi channel waveform for channels $(channelnames(s)[idx])")
         fig = plot_multi_channel_timeseries(
             s.data[:, idx],
-            samplingrate(s),
+            samplingrate(Float64, s),
             channelnames(s)[idx];
             kwargs...,
         )

--- a/src/types/SSR/Preprocessing.jl
+++ b/src/types/SSR/Preprocessing.jl
@@ -24,7 +24,7 @@ c = highpass_filter(a, cutOff = 1)
 function highpass_filter(
     a::SSR;
     cutOff::Real = 2,
-    fs::Real = samplingrate(a),
+    fs::Real = samplingrate(Float64, a),
     order::Int = 3,
     tolerance::Real = 0.01,
     kwargs...,
@@ -57,7 +57,7 @@ c = lowpass_filter(a, cutOff = 1)
 function lowpass_filter(
     a::SSR;
     cutOff::Real = 150,
-    fs::Real = samplingrate(a),
+    fs::Real = samplingrate(Float64, a),
     order::Int = 3,
     tolerance::Real = 0.01,
     kwargs...,
@@ -101,9 +101,9 @@ function bandpass_filter(
     # TODO filter check does not work here. Why not?
     # TODO automatic minimum filter order selection
 
-    a.data, f = bandpass_filter(a.data, lower, upper, samplingrate(a), n, rp)
+    a.data, f = bandpass_filter(a.data, lower, upper, samplingrate(Float64, a), n, rp)
 
-    _filter_check(f, modulationrate(a), samplingrate(a), tolerance)
+    _filter_check(f, modulationrate(a), samplingrate(Float64, a), tolerance)
 
     _append_filter(a, f)
 end
@@ -178,7 +178,7 @@ function downsample(s::SSR, ratio::Rational)
         s.triggers["Index"][1] = 1
     end
 
-    s.samplingrate = float(samplingrate(s) * ratio) * 1.0u"Hz"
+    s.samplingrate = float(samplingrate(Float64, s) * ratio) * 1.0u"Hz"
 
     return s
 end

--- a/src/types/SSR/Reshaping.jl
+++ b/src/types/SSR/Reshaping.jl
@@ -95,14 +95,14 @@ function add_triggers(
 
     # Existing epochs
     existing_epoch_length = median(diff(epochIndex[!, :Index]))     # samples
-    existing_epoch_length_s = existing_epoch_length / samplingrate(a)
+    existing_epoch_length_s = existing_epoch_length / samplingrate(Float64, a)
     @debug("Existing epoch length: $(existing_epoch_length_s)s")
 
     # New epochs
     new_epoch_length_s = cycle_per_epoch / mod_freq
     new_epochs_num = round.(existing_epoch_length_s / new_epoch_length_s) - 2
     new_epoch_times = collect(1:new_epochs_num) * new_epoch_length_s
-    new_epoch_indx = [0; round.(new_epoch_times * samplingrate(a))]
+    new_epoch_indx = [0; round.(new_epoch_times * samplingrate(Float64, a))]
     @debug("New epoch length = $new_epoch_length_s")
     @debug("New # epochs     = $new_epochs_num")
 

--- a/src/types/SSR/SSR.jl
+++ b/src/types/SSR/SSR.jl
@@ -75,7 +75,7 @@ modulationrate(s::SSR) = modulationrate(AbstractFloat, s)
 
 import Base.show
 function Base.show(io::IO, a::SSR)
-    time_length = round.(size(a.data, 1) / samplingrate(a) / 60)
+    time_length = round.(size(a.data, 1) / samplingrate(Float64, a) / 60)
     println(
         io,
         "SSR measurement of $time_length mins with $(size(a.data,2)) channels sampled at $(a.samplingrate)",

--- a/src/types/SSR/Statistics.jl
+++ b/src/types/SSR/Statistics.jl
@@ -44,8 +44,9 @@ function ftest(
 
     # Do calculation here once, instead of in each low level call
     spectrum = Neuroimaging._ftest_spectrum(s.processing["sweeps"])
-    spectrum = compensate_for_filter(s.processing, spectrum, samplingrate(s))
-    frequencies = range(0, stop = 1, length = Int(size(spectrum, 1))) * samplingrate(s) / 2
+    spectrum = compensate_for_filter(s.processing, spectrum, samplingrate(Float64, s))
+    frequencies =
+        range(0, stop = 1, length = Int(size(spectrum, 1))) * samplingrate(Float64, s) / 2
 
     for freq in freq_of_interest
 

--- a/src/types/Sensors/Sensors.jl
+++ b/src/types/Sensors/Sensors.jl
@@ -63,7 +63,7 @@ end
 import Base.show
 function show(s::S) where {S<:Sensor}
     println(
-        "Sensor: $(s.label) $(typeof(s)) - ($(s.coordinate.x), $(s.coordinate.y), $(s.coordinate.z)) ($(typeof(s.coordinate)))",
+        "Sensor: $(s.label) $(typeof(s)) - ($(s.coordinate.x |> u"mm"), $(s.coordinate.y |> u"mm"), $(s.coordinate.z |> u"mm")) ($(typeof(s.coordinate)))",
     )
 end
 

--- a/test/datasets/datasets.jl
+++ b/test/datasets/datasets.jl
@@ -4,7 +4,7 @@ using Neuroimaging, DataDeps, Test
 # Basic biosemi data file
 data_path = joinpath(datadep"BioSemiTestFiles", "Newtest17-2048.bdf")
 s = read_SSR(data_path)
-@test samplingrate(s) == 2048
+@test samplingrate(s) == 2048u"Hz"
 @test length(channelnames(s)) == 16
 @test length(s.triggers["Index"]) == length(s.triggers["Code"])
 @test length(s.triggers["Code"]) == length(s.triggers["Duration"])
@@ -17,7 +17,7 @@ data_path = joinpath(
     "neuroimaingSSR.bdf",
 )
 s = read_SSR(data_path)
-@test samplingrate(s) == 8192
+@test samplingrate(s) == 8192u"Hz"
 @test length(channelnames(s)) == 7
 @test length(s.triggers["Index"]) == length(s.triggers["Code"])
 @test length(s.triggers["Code"]) == length(s.triggers["Duration"])

--- a/test/plotting/plots.jl
+++ b/test/plotting/plots.jl
@@ -12,7 +12,7 @@
         p = plot_spectrum(s, "20Hz_SWN_70dB_R", targetFreq = 3.0)
         #= display(p) =#
 
-        p = plot_spectrum(vec(s.data[:, 1]), Int(samplingrate(s)), dBPlot = false)
+        p = plot_spectrum(vec(s.data[:, 1]), samplingrate(Int, s), dBPlot = false)
         #= display(p) =#
 
         p = plot_spectrum(s, 3, targetFreq = 40.0390625)
@@ -21,7 +21,7 @@
 
     @testset "Filter reponse" begin
 
-        p = plot_filter_response(s.processing["filter1"], Int(samplingrate(s)))
+        p = plot_filter_response(s.processing["filter1"], samplingrate(Int, s))
         #= display(p) =#
     end
 

--- a/test/types/EEG.jl
+++ b/test/types/EEG.jl
@@ -17,11 +17,9 @@ using Neuroimaging, Test, BDF
 
         s = read_EEG(fname)
 
-        @info samplingrate(s)
-        @test samplingrate(s) == 8192.0
-        @info samplingrate(s)
+        @test samplingrate(s) == 8192.0u"Hz"
         @test samplingrate(Int, s) == 8192
-        @test isa(samplingrate(s), AbstractFloat) == true
+        @test isa(samplingrate(Float64, s), AbstractFloat) == true
         @test isa(samplingrate(Int, s), Int) == true
 
         @test isapprox(maximum(s.data[:, 2]), 54.5939; atol = 0.1)
@@ -40,7 +38,7 @@ using Neuroimaging, Test, BDF
         @test length(s.triggers["Index"]) == 12
 
         s = read_EEG(fname)
-        s.triggers = extra_triggers(s.triggers, 1, 7, 0.7, samplingrate(s))
+        s.triggers = extra_triggers(s.triggers, 1, 7, 0.7, samplingrate(Float64, s))
         @test length(s.triggers["Index"]) == 56
     end
 

--- a/test/types/SSR/SSR.jl
+++ b/test/types/SSR/SSR.jl
@@ -20,11 +20,9 @@
 
         s = read_SSR(fname2)
 
-        @info samplingrate(s)
-        @test samplingrate(s) == 8192.0
-        @info samplingrate(s)
+        @test samplingrate(s) == 8192.0u"Hz"
         @test samplingrate(Int, s) == 8192
-        @test isa(samplingrate(s), AbstractFloat) == true
+        @test isa(samplingrate(Float64, s), AbstractFloat) == true
         @test isa(samplingrate(Int, s), Int) == true
 
         @info modulationrate(s)
@@ -47,7 +45,7 @@
         @test length(s.triggers["Index"]) == 12
 
         s = read_SSR(fname)
-        s.triggers = extra_triggers(s.triggers, 1, 7, 0.7, samplingrate(s))
+        s.triggers = extra_triggers(s.triggers, 1, 7, 0.7, samplingrate(Float64, s))
         @test length(s.triggers["Index"]) == 56
     end
 


### PR DESCRIPTION
#### Reference issue
All data should be passed around with units unless explicitly requested by the user.

#### What does this implement/fix?
samplingrate now returns data with units by default

#### Additional information
Breaking change